### PR TITLE
Ładowanie WorldEdita przed pluginem

### DIFF
--- a/resource/plugin.yml
+++ b/resource/plugin.yml
@@ -3,6 +3,7 @@ main: net.dzikoysk.funnyguilds.FunnyGuilds
 version: 2.7.2 Valor Beta
 author: Dzikoysk
 website: http://www.dzikoysk.net/
+loadbefore: [WorldEdit]
 permissions:
     funnyguilds.*:
         default: op


### PR DESCRIPTION
Gdy WorldEdit ładuje się po pluginie FunnyGuilds, nadpisuje on komendę /info, przez co dostępna jest ona tylko poprzez aliasy.